### PR TITLE
Simplify how entries are loaded

### DIFF
--- a/.github/workflows/style-lint-and-test.yaml
+++ b/.github/workflows/style-lint-and-test.yaml
@@ -32,7 +32,9 @@ jobs:
           version: "latest"
 
       - name: Install Dependencies
-        run: make setup
+        run: |
+          echo ${{ matrix.python-version }} > .python-version
+          make setup
 
       - name: Check the Code style
         run: make codestyle

--- a/.github/workflows/style-lint-and-test.yaml
+++ b/.github/workflows/style-lint-and-test.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,8 @@
 **Released: WiP**
 
 - Exported `Link` at the top-level of the library.
+- Changed the way that entries are loaded so that type checks don't get
+  confused. [#8](https://github.com/davep/ngdb.py/issues/8)
 
 ## v0.7.0
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ classifiers = [
     "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
     "Development Status :: 3 - Alpha",
     "Operating System :: OS Independent",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
     "typing-extensions",
 ]
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = { text = "GNU General Public License v3 or later (GPLv3+)" }
 keywords = [
     "library",

--- a/src/ngdb/entry.py
+++ b/src/ngdb/entry.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 ##############################################################################
 # Python imports.
-from typing import Callable, Final, Iterator
+from typing import Final, Iterator
 
 ##############################################################################
 # Local imports.
@@ -14,7 +14,6 @@ from .link import Link
 from .parser import RichText
 from .reader import GuideReader
 from .seealso import SeeAlso
-from .types import EntryType, UnknownEntryType
 
 
 ##############################################################################
@@ -111,54 +110,6 @@ MAX_LINE_LENGTH: Final[int] = 1024
 ##############################################################################
 class Entry:
     """Norton Guide database entry class."""
-
-    _map: dict[EntryType, type[Entry]] = {}
-    """Holds the entry type mapper."""
-
-    @classmethod
-    def loads(cls, entry_type: EntryType) -> Callable[[type[Entry]], type[Entry]]:
-        """Decorator for defining which class handles which entry type.
-
-        Args:
-            entry_type: The ID of the entry type being handled.
-
-        Returns:
-            The decorator wrapper.
-
-        Example:
-            ```python
-            @Entry.loads(EntryType.SHORT)
-            class Short(Entry):
-                ...
-            ```
-        """
-
-        def _register(handler: type[Entry]) -> type[Entry]:
-            """Inner decorator function."""
-            cls._map[entry_type] = handler
-            return handler
-
-        return _register
-
-    @classmethod
-    def load(cls, guide: GuideReader) -> Entry:
-        """Load the entry at the current position in the guide.
-
-        Args:
-            guide: The reader object for the guide.
-
-        Returns:
-            The correct type of entry object.
-
-        Raises:
-            UnknownEntryType: Indicates that the entry type is unknown.
-        """
-        try:
-            return cls._map[EntryType(guide.peek_word())](guide)
-        except (ValueError, KeyError) as error:
-            raise UnknownEntryType(
-                f"Unknown guide entry type: {guide.peek_word()}"
-            ) from error
 
     def __init__(self, guide: GuideReader) -> None:
         """Constructor.
@@ -274,7 +225,6 @@ class Entry:
 
 
 ##############################################################################
-@Entry.loads(EntryType.SHORT)
 class Short(Entry):
     """Short Norton Guide database entry."""
 
@@ -330,7 +280,6 @@ class Short(Entry):
 
 
 ##############################################################################
-@Entry.loads(EntryType.LONG)
 class Long(Entry):
     """Long Norton Guide database entry."""
 

--- a/src/ngdb/guide.py
+++ b/src/ngdb/guide.py
@@ -247,7 +247,7 @@ class NortonGuide:
 
         Returns:
             The entry found at the current position. Either a
-            [`Short`][ngdb.Short] or a [`Long`][ngdb.Long] entry.
+              [`Short`][ngdb.Short] or a [`Long`][ngdb.Long] entry.
 
         Raises:
             NGEOF: If we attempt to load when at EOF.
@@ -276,7 +276,7 @@ class NortonGuide:
 
         Yields:
             An entry from the guide. Either a [`Short`][ngdb.Short] or a
-            [`Long`][ngdb.Long] entry.
+              [`Long`][ngdb.Long] entry.
 
         Raises:
             UnknownEntryType: If an unknown type of entry is encountered.


### PR DESCRIPTION
Closes #8.

Also changes how the workflow for testing runs, ensuring that the actual Python version in the matrix is used for the tests.

Also bumps the minimum Python version to 3.10.