### PR TITLE
Adds `NortonGuide.maybe`

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,11 @@
 # ChangeLog
 
+## Unreleased
+
+**Released: WiP**
+
+- Added `NortonGuide.maybe`.
+
 ## v0.8.0
 
 **Released: 2025-03-09**

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,7 @@
 **Released: WiP**
 
 - Added `NortonGuide.maybe`.
+  ([#11](https://github.com/davep/ngdb.py/pull/11))
 
 ## v0.8.0
 

--- a/src/ngdb/guide.py
+++ b/src/ngdb/guide.py
@@ -96,6 +96,29 @@ class NortonGuide:
             # let's remember where that is.
             self._first_entry = self._guide.pos
 
+    @staticmethod
+    def maybe(candidate: Path) -> bool:
+        """Does the given file look like it might be a Norton Guide?
+
+        Args:
+            candidate: The file to consider.
+
+        Returns:
+            [`True`][True] if the file might be a Norton Guide,
+                [`False`][False] if not.
+
+        Notes:
+            The content of the file is *not* looked at here, just the name
+            of the file. This means it can be used as a fast initial filter.
+            To see if a file is *really* a Norton Guide open it with
+            [`NortonGuide`][ngdb.NortonGuide] and check
+            [`is_a`][ngdb.NortonGuide.is_a].
+
+            Also keep in mind that even the existence of the file isn't
+            taken into account.
+        """
+        return candidate.suffix.lower() == ".ng"
+
     @property
     def path(self) -> Path:
         """The path to the guide."""

--- a/tests/test_guide_maybe.py
+++ b/tests/test_guide_maybe.py
@@ -1,0 +1,31 @@
+"""Test the facility for checking if a file might be a guide."""
+
+##############################################################################
+# Python imports.
+from pathlib import Path
+
+##############################################################################
+# Pytest imports.
+from pytest import mark
+
+##############################################################################
+# Local imports.
+from ngdb import NortonGuide
+
+##############################################################################
+@mark.parametrize("candidate, expected_result", (
+    (Path(""), False),
+    (Path("foo.txt"), False),
+    (Path("foo.ng"), True),
+    (Path("foo.NG"), True),
+    (Path("foo.Ng"), True),
+    (Path("foo.nG"), True),
+    (Path("foo.bar.baz.ng"), True),
+    (Path("foo.ng."), False),
+    (Path("foo.ng.gz"), False),
+))
+def test_maybe_guide(candidate: Path, expected_result: bool) -> None:
+    """We should be able to check which files might be a Norton Guide."""
+    assert NortonGuide.maybe(candidate) is expected_result
+
+### test_guide_maybe.py ends here

--- a/tests/test_guide_maybe.py
+++ b/tests/test_guide_maybe.py
@@ -18,6 +18,10 @@ from ngdb import NortonGuide
     "candidate, expected_result",
     (
         (Path(""), False),
+        (Path("ng"), False),
+        (Path("ng."), False),
+        (Path(".ng"), False),
+        (Path(".ng.ng"), True),
         (Path("foo.txt"), False),
         (Path("foo.ng"), True),
         (Path("foo.NG"), True),
@@ -25,6 +29,7 @@ from ngdb import NortonGuide
         (Path("foo.nG"), True),
         (Path("foo.bar.baz.ng"), True),
         (Path("foo.ng."), False),
+        (Path("foo.ngng"), False),
         (Path("foo.ng.gz"), False),
     ),
 )

--- a/tests/test_guide_maybe.py
+++ b/tests/test_guide_maybe.py
@@ -12,20 +12,25 @@ from pytest import mark
 # Local imports.
 from ngdb import NortonGuide
 
+
 ##############################################################################
-@mark.parametrize("candidate, expected_result", (
-    (Path(""), False),
-    (Path("foo.txt"), False),
-    (Path("foo.ng"), True),
-    (Path("foo.NG"), True),
-    (Path("foo.Ng"), True),
-    (Path("foo.nG"), True),
-    (Path("foo.bar.baz.ng"), True),
-    (Path("foo.ng."), False),
-    (Path("foo.ng.gz"), False),
-))
+@mark.parametrize(
+    "candidate, expected_result",
+    (
+        (Path(""), False),
+        (Path("foo.txt"), False),
+        (Path("foo.ng"), True),
+        (Path("foo.NG"), True),
+        (Path("foo.Ng"), True),
+        (Path("foo.nG"), True),
+        (Path("foo.bar.baz.ng"), True),
+        (Path("foo.ng."), False),
+        (Path("foo.ng.gz"), False),
+    ),
+)
 def test_maybe_guide(candidate: Path, expected_result: bool) -> None:
     """We should be able to check which files might be a Norton Guide."""
     assert NortonGuide.maybe(candidate) is expected_result
+
 
 ### test_guide_maybe.py ends here


### PR DESCRIPTION
Adds a static method to `NortonGuide` that can be used to quickly check if a given file _might_ be a Norton Guide, based just on the name of the file.
