### PR TITLE
Add a tool for testing all the guides I have

### DIFF
--- a/.comprehensive_test/read_all_known_guides
+++ b/.comprehensive_test/read_all_known_guides
@@ -1,0 +1,136 @@
+#!/bin/env python
+
+##############################################################################
+# Python imports.
+from argparse import ArgumentParser, Namespace
+from pathlib import Path
+from typing import Iterator, NamedTuple, TypeAlias
+
+##############################################################################
+# NGDB imports.
+from ngdb import NortonGuide
+from ngdb.entry import Long, Short, Link
+from ngdb.parser import PlainText
+
+##############################################################################
+def lines_of(entry: Short | Long) -> Iterator[str]:
+    """Get the lines from an entry.
+
+    Args:
+        entry: The entry to get the lines of.
+
+    Yields:
+        Each line of text from the entry.
+    """
+    for line in entry:
+        yield line.text if isinstance(line, Link) else line
+
+##############################################################################
+class GuideError(NamedTuple):
+    """Class that holds details of a guide-related error."""
+
+    guide: NortonGuide
+    """The guide that caused the error."""
+    error: Exception
+    """The error."""
+
+##############################################################################
+class EntryError(NamedTuple):
+    """Class that holds details of an entry-related error."""
+
+    guide: NortonGuide
+    """The guide that caused the error."""
+    entry: Long | Short
+    """The entry that caused the error."""
+    line: str
+    """The line of source that caused the error."""
+    error: Exception
+    """The error."""
+
+##############################################################################
+FoundError: TypeAlias = GuideError | EntryError
+"""Type for an error found while testing guides."""
+
+##############################################################################
+def read_all_of(guide: NortonGuide) -> Iterator[GuideError | EntryError]:
+    """Read and parse every entry in the given guide.
+
+    Args:
+        guide: The guide to test.
+    """
+    print(f"Reading {guide.path.name}")
+    try:
+        for entry in guide:
+            print(entry.__class__.__name__[0], end="", flush=True)
+            for line in lines_of(entry):
+                try:
+                    _ = PlainText(line)
+                except Exception as error:
+                    yield EntryError(guide, entry, line, error)
+    except Exception as error:
+        yield GuideError(guide, error)
+    print("\n")
+
+##############################################################################
+def entry_path(guide: NortonGuide, entry: Long | Short) -> Iterator[str]:
+    """Generate a path for finding the entry.
+
+    Args:
+        guide: The guide being tested.
+        entry: The entry to get the path to.
+
+    Yields:
+        The parts of the path.
+    """
+    if entry.parent.has_menu:
+        yield guide.menus[entry.parent.menu].title
+    if entry.parent.has_prompt:
+        yield guide.menus[entry.parent.menu].prompts[entry.parent.prompt]
+    if entry.parent.has_line:
+        yield str(entry.parent.line)
+
+##############################################################################
+def main(guides: Path) -> None:
+    """Main entry point."""
+    errors: list[FoundError] = []
+    for candidate in [guides] if guides.is_file() else guides.glob("*.[Nn][Gg]"):
+        with NortonGuide(candidate) as guide:
+            errors.extend(read_all_of(guide))
+    for error in errors:
+        if isinstance(error, GuideError):
+            print(f"Navigation error in {error.guide.path.name}:")
+            print(str(error.error))
+        else:
+            print(f"Entry reading error in {error.guide.path.name}:")
+            print(f"Entry: {', '.join(entry_path(error.guide, error.entry))}")
+            print(f"Line: {error.line}")
+            print(str(error.error))
+        print("-" * 80)
+        print()
+
+##############################################################################
+def get_args() -> Namespace:
+    """Get the command line arguments.
+
+    Returns:
+        The arguments.
+    """
+    parser = ArgumentParser(
+        prog="read_all_known_guides",
+        description="Tool to shake down the library using all the guides I have",
+    )
+    parser.add_argument(
+        "location",
+        nargs="?",
+        type=Path,
+        help="A guide to open or a directory to scan",
+    )
+
+    # Finally, parse the command line.
+    return parser.parse_args()
+
+##############################################################################
+if __name__ == "__main__":
+    main(get_args().location or Path("~/Documents/Norton Guides").expanduser())
+
+### read_all_known_guides ends here

--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,10 @@ stricttypecheck:	        # Perform a strict static type checks with mypy
 test:				# Run the unit tests
 	$(test) -v
 
+.PHONY: comprehensive-test
+comprehensive-test:		# Read all the guides I have to test them
+	$(run) python .comprehensive_test/read_all_known_guides
+
 .PHONY: checkall
 checkall: codestyle lint stricttypecheck test # Check all the things
 


### PR DESCRIPTION
In adding a global search facility to AgiNG (https://github.com/davep/aging/pull/18) I encountered a small number of guides that have unexpected or malformed content; this in turn caused crashes. Having run into this sort of thing with WEG, and added various workarounds for these problems, I decided it would make sense to have a tool in this repository that would mimic the global search.

So this tool reads and parses every single entry in every single guide I have available, or a specific guide if I want to do a quick test, and it reports any errors it finds.

Once this tool emits zero errors, thus taking the approach of accepting broken guides so make them work, the whole library will be even more robust.