### PR TITLE
Handle guides with malformed ^a and ^c

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,10 @@
 
 - `NortonGuide.maybe` now accepts `str` as well as `Path`.
   ([#16](https://github.com/davep/ngdb.py/pull/16))
+- Handle parsing entries that contain an invalid `^a` (generally what should
+  have been a `^^a`).
+- Handle parsing entries that contain an invalid `^c` (generally what should
+  have been a `^^c`).
 
 ## v0.9.0
 

--- a/src/ngdb/parser.py
+++ b/src/ngdb/parser.py
@@ -130,7 +130,14 @@ class BaseParser:
         """
 
         # Get the actual attribute.
-        attr = int(state.raw[state.ctrl + 2 : state.ctrl + 4], 16)
+        try:
+            attr = int(state.raw[state.ctrl + 2 : state.ctrl + 4], 16)
+        except ValueError:
+            # There wasn't a valid hex value after the ^a, so assume that
+            # someone typed ^^a wrong and pretend it's a ^a.
+            self.text(state.raw[state.ctrl : state.ctrl + 2])
+            state.ctrl += 2
+            return
 
         # If there's already a colour attribute in effect and the
         # new colour is the same as the previous colour...
@@ -173,7 +180,15 @@ class BaseParser:
         Args:
             state: The data that tracks parse state.
         """
-        self.char(int(state.raw[state.ctrl + 2 : state.ctrl + 4], 16))
+        try:
+            character = int(state.raw[state.ctrl + 2 : state.ctrl + 4], 16)
+        except ValueError:
+            # There wasn't a valid hex value after the ^c, so assume that
+            # someone typed ^^c wrong and pretend it's a ^c.
+            self.text(state.raw[state.ctrl : state.ctrl + 2])
+            state.ctrl += 2
+            return
+        self.char(character)
         state.ctrl += 4
 
     def _ctrl_n(self, state: ParseState) -> None:

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -197,6 +197,31 @@ class TestParseEvents:
 
 
 ##############################################################################
+class TestParseBadSource:
+    """Test various examples of bad guide source I've encountered."""
+
+    def test_unescaped_ctrl_a(self) -> None:
+        """A ^a that doesn't seem to be followed by numbers should be treated as a ^a."""
+        assert list(MockedParser("This is a ^a that ^aisn't escaped correctly")) == [
+            ("T", "This is a "),
+            ("T", "^a"),
+            ("T", " that "),
+            ("T", "^a"),
+            ("T", "isn't escaped correctly"),
+        ]
+
+    def test_unescaped_ctrl_c(self) -> None:
+        """A ^c that doesn't seem to be followed by numbers should be treated as a ^c."""
+        assert list(MockedParser("This is a ^c that ^cisn't escaped correctly")) == [
+            ("T", "This is a "),
+            ("T", "^c"),
+            ("T", " that "),
+            ("T", "^c"),
+            ("T", "isn't escaped correctly"),
+        ]
+
+
+##############################################################################
 class TestRichParser:
     """Test the Rich-friendly parser."""
 


### PR DESCRIPTION
Closes #18.