### PR TITLE
Handle a lone `0xFF` at the end of a string when expanding RLE spaces

### DIFF
--- a/.comprehensive_test/read_all_known_guides
+++ b/.comprehensive_test/read_all_known_guides
@@ -4,6 +4,7 @@
 # Python imports.
 from argparse import ArgumentParser, Namespace
 from pathlib import Path
+from traceback import format_exception
 from typing import Iterator, NamedTuple, TypeAlias
 
 ##############################################################################
@@ -99,12 +100,12 @@ def main(guides: Path) -> None:
     for error in errors:
         if isinstance(error, GuideError):
             print(f"Navigation error in {error.guide.path.name}:")
-            print(str(error.error))
+            print("\n".join(format_exception(error.error)))
         else:
             print(f"Entry reading error in {error.guide.path.name}:")
             print(f"Entry: {', '.join(entry_path(error.guide, error.entry))}")
             print(f"Line: {error.line}")
-            print(str(error.error))
+            print("\n".join(format_exception(error.error)))
         print("-" * 80)
         print()
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -10,6 +10,7 @@
   have been a `^^a`).
 - Handle parsing entries that contain an invalid `^c` (generally what should
   have been a `^^c`).
+- Handle 0xFF characters at the very end of a string.
 
 ## v0.9.0
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,10 +7,11 @@
 - `NortonGuide.maybe` now accepts `str` as well as `Path`.
   ([#16](https://github.com/davep/ngdb.py/pull/16))
 - Handle parsing entries that contain an invalid `^a` (generally what should
-  have been a `^^a`).
+  have been a `^^a`). ([#21](https://github.com/davep/ngdb.py/pull/21))
 - Handle parsing entries that contain an invalid `^c` (generally what should
-  have been a `^^c`).
+  have been a `^^c`). ([#21](https://github.com/davep/ngdb.py/pull/21))
 - Handle 0xFF characters at the very end of a string.
+  ([#22](https://github.com/davep/ngdb.py/pull/22))
 
 ## v0.9.0
 

--- a/src/ngdb/reader.py
+++ b/src/ngdb/reader.py
@@ -55,9 +55,19 @@ class GuideReader:
         split = rle_text.find(cls.RLE_MARKER)
 
         while split > -1:
-            expanded += rle_text[start:split] + " " * (
-                1 if rle_text[split + 1] == cls.RLE_MARKER else ord(rle_text[split + 1])
-            )
+            try:
+                expanded += rle_text[start:split] + " " * (
+                    1
+                    if rle_text[split + 1] == cls.RLE_MARKER
+                    else ord(rle_text[split + 1])
+                )
+            except IndexError:
+                # It looks like there's a marker at the end of the string,
+                # with nothing to follow it. Let's also assume that's
+                # supposed to be a space.
+                expanded += " "
+                start += 1
+                break
             start = split + 2
             split = rle_text.find(cls.RLE_MARKER, start)
 

--- a/tests/test_unrle.py
+++ b/tests/test_unrle.py
@@ -1,0 +1,30 @@
+"""Test the code that handles expanding run-length-encoded spaces."""
+
+##############################################################################
+# Pytest imports.
+from pytest import mark
+
+##############################################################################
+# Local imports.
+from ngdb.reader import GuideReader
+
+
+##############################################################################
+@mark.parametrize(
+    "compressed, expanded",
+    [
+        ("", ""),
+        (" ", " "),
+        ("\xff\x00", ""),
+        ("\xff\x01", " "),
+        ("\xff\x0a", " " * 10),
+        ("\xff\xff", " "),
+        ("\xff", " "),
+    ],
+)
+def test_unrle(compressed: str, expanded: str) -> None:
+    """The code to expand run-length-encoded spaces should work."""
+    assert GuideReader.unrle(compressed) == expanded
+
+
+### test_unrle.py ends here


### PR DESCRIPTION
Closes #17.