### PR TITLE
Add more aggressive EOF checking

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -12,6 +12,7 @@
   have been a `^^c`). ([#21](https://github.com/davep/ngdb.py/pull/21))
 - Handle 0xFF characters at the very end of a string.
   ([#22](https://github.com/davep/ngdb.py/pull/22))
+- Added `NortonGuide.file_size`.
 
 ## v0.9.0
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -13,6 +13,10 @@
 - Handle 0xFF characters at the very end of a string.
   ([#22](https://github.com/davep/ngdb.py/pull/22))
 - Added `NortonGuide.file_size`.
+  ([#23](https://github.com/davep/ngdb.py/pull/23))
+- Added more aggressive end-of-file checking (`NGEOF` more likely to be
+  raised when encountering a mangled/truncated guide).
+  ([#23](https://github.com/davep/ngdb.py/pull/23))
 
 ## v0.9.0
 

--- a/src/ngdb/guide.py
+++ b/src/ngdb/guide.py
@@ -250,7 +250,19 @@ class NortonGuide:
     @property
     def eof(self) -> bool:
         """Are we at the end of the guide?"""
-        return self._guide.pos >= self._file_size
+        # To start with, if we're at the end, we're at the end.
+        if self._guide.pos >= self._file_size:
+            return True
+        # With that cheap check out of the way, we then peek at what is at
+        # the current location. It should be the marker for a short or a
+        # long entry; anything else likely indicates a corrupt file.
+        try:
+            return EntryType(self._guide.peek_word()) not in (
+                EntryType.SHORT,
+                EntryType.LONG,
+            )
+        except ValueError:
+            return True
 
     @not_eof
     def load(self) -> Short | Long:

--- a/src/ngdb/guide.py
+++ b/src/ngdb/guide.py
@@ -75,6 +75,8 @@ class NortonGuide:
         """The path to the guide."""
         self._guide = GuideReader(self._path)
         """The guide reading object."""
+        self._file_size = self._path.stat().st_size
+        """The size of the guide in bytes."""
         if self._read_header().is_a:
             self._menus = tuple(menu for menu in self._read_menus())
             """The menus for the guide."""
@@ -109,6 +111,11 @@ class NortonGuide:
     def path(self) -> Path:
         """The path to the guide."""
         return self._path
+
+    @property
+    def file_size(self) -> int:
+        """The size of the guide in bytes."""
+        return self._file_size
 
     def _read_header(self) -> Self:
         """Read the header of the Norton Guide database.
@@ -243,7 +250,7 @@ class NortonGuide:
     @property
     def eof(self) -> bool:
         """Are we at the end of the guide?"""
-        return self._guide.pos >= self._path.stat().st_size
+        return self._guide.pos >= self._file_size
 
     @not_eof
     def load(self) -> Short | Long:

--- a/src/ngdb/guide.py
+++ b/src/ngdb/guide.py
@@ -250,19 +250,7 @@ class NortonGuide:
     @property
     def eof(self) -> bool:
         """Are we at the end of the guide?"""
-        # To start with, if we're at the end, we're at the end.
-        if self._guide.pos >= self._file_size:
-            return True
-        # With that cheap check out of the way, we then peek at what is at
-        # the current location. It should be the marker for a short or a
-        # long entry; anything else likely indicates a corrupt file.
-        try:
-            return EntryType(self._guide.peek_word()) not in (
-                EntryType.SHORT,
-                EntryType.LONG,
-            )
-        except ValueError:
-            return True
+        return self._guide.pos >= self._file_size
 
     @not_eof
     def load(self) -> Short | Long:

--- a/src/ngdb/reader.py
+++ b/src/ngdb/reader.py
@@ -155,8 +155,7 @@ class GuideReader:
         """
         if buff := self._h.read(1):
             return self._decrypt(buff[0]) if decrypt else buff[0]
-        else:
-            raise NGEOF
+        raise NGEOF
 
     def read_word(self, decrypt: bool = True) -> int:
         """Read a two-byte word from the guide.

--- a/src/ngdb/reader.py
+++ b/src/ngdb/reader.py
@@ -10,6 +10,10 @@ from typing import Final
 # Typing backward compatibility.
 from typing_extensions import Self
 
+##############################################################################
+# Local imports.
+from .types import NGEOF
+
 
 ##############################################################################
 class GuideReader:
@@ -149,8 +153,10 @@ class GuideReader:
         Returns:
             The byte value read.
         """
-        buff = self._h.read(1)[0]
-        return self._decrypt(buff) if decrypt else buff
+        if buff := self._h.read(1):
+            return self._decrypt(buff[0]) if decrypt else buff[0]
+        else:
+            raise NGEOF
 
     def read_word(self, decrypt: bool = True) -> int:
         """Read a two-byte word from the guide.

--- a/src/ngdb/types.py
+++ b/src/ngdb/types.py
@@ -11,13 +11,13 @@ class NGDBError(Exception):
 
 
 ##############################################################################
-class UnknownEntryType(NGDBError):
-    """Type of an exception when faced with an unknown entry type."""
+class NGEOF(NGDBError):
+    """Type of an exception thrown when doing things at or past EOF."""
 
 
 ##############################################################################
-class NGEOF(NGDBError):
-    """Type of an exception thrown when doing things at or past EOF."""
+class UnknownEntryType(NGEOF):
+    """Type of an exception when faced with an unknown entry type."""
 
 
 ##############################################################################

--- a/src/ngdb/types.py
+++ b/src/ngdb/types.py
@@ -17,7 +17,15 @@ class NGEOF(NGDBError):
 
 ##############################################################################
 class UnknownEntryType(NGEOF):
-    """Type of an exception when faced with an unknown entry type."""
+    """Type of an exception when faced with an unknown entry type.
+
+    Note:
+        This class is a subclass of [`NGEOF`][ngdb.NGEOF] so if you are
+        writing code that walks a guide and you want to stop once an unknown
+        guide type is found (often indicating a corrupted guide), you can
+        safely catch [`NGEOF`][ngdb.NGEOF] and this exception will be
+        handled.
+    """
 
 
 ##############################################################################


### PR DESCRIPTION
I have a couple of guides to hand that seem to be corrupt in some way; most likely truncated before they ever got sent to me (very likely sent to me because they were truncated -- I got sent a lot of guides that caused issues with early versions of WEG back in the late 1990s and early 2000s). This PR makes the EOF checks a wee bit more aggressive so any application using this library can safely work through as much of such a guide as possible.