### PR TITLE
Remove an unnecessary inline assignment from a test

### DIFF
--- a/tests/test_guide_entry.py
+++ b/tests/test_guide_entry.py
@@ -196,7 +196,7 @@ def test_long_next(long: Long) -> None:
 ##############################################################################
 def test_long_str_entry(long: Long) -> None:
     """The str() of the test long entry should be the main text."""
-    assert len((str_entry := str(long)).split("\n")) == len(long)
+    assert len(str(long).split("\n")) == len(long)
 
 
 ##############################################################################


### PR DESCRIPTION
Likely a vestige of a previous version of the test, or a copy/paste-o from elsewhere. It's not necessary so let's clean it up...